### PR TITLE
Parser state machine cleanup

### DIFF
--- a/bl808-data/src/lib.rs
+++ b/bl808-data/src/lib.rs
@@ -66,7 +66,10 @@ pub fn parseit(
         }
         // Looking for register address: "/* 0x0 : soc_info0 */""
         ParseState::RegAddress => {
-            if let Some(m) = regex!(r"\s*\.*/* (0x[a-fA-F_\d]*) : (.*) \*/").captures(&line) {
+            if let Some(m) = regex!(r"};").captures(&line) {
+                state = ParseState::PeripheralStart;
+                (state, None)
+            } else if let Some(m) = regex!(r"\s*\.*/* (0x[a-fA-F_\d]*) : (.*) \*/").captures(&line) {
                 state = ParseState::UnionStart;
                 // 1st capture is register offset
                 data.push(String::from(m.get(1).unwrap().as_str()));

--- a/bl808-data/src/lib.rs
+++ b/bl808-data/src/lib.rs
@@ -166,6 +166,11 @@ pub fn parseit(
                 data.push(String::from(m.get(0).unwrap().as_str()));
                 event!(Level::TRACE, "\nCaptures: {}", data[0]);
                 (state, Some(ParseResult::Capture(data)))
+            } else if let Some(m) = regex!(r"\s*(uint16_t)\s*SHORT;").captures(&line) {
+                state = ParseState::Name;
+                data.push(String::from(m.get(0).unwrap().as_str()));
+                event!(Level::TRACE, "\nCaptures: {}", data[0]);
+                (state, Some(ParseResult::Capture(data)))
             } else {
                 event!(
                     Level::TRACE,

--- a/bl808-data/src/lib.rs
+++ b/bl808-data/src/lib.rs
@@ -161,11 +161,11 @@ pub fn parseit(
         }
         // Looking for 2nd union member: "uint32_t WORD;"
         ParseState::Size => {
-            if let Some(m) = regex!(r"\s*uint32_t WORD;").captures(&line) {
+            if let Some(m) = regex!(r"\s*(uint32_t) WORD;").captures(&line) {
                 state = ParseState::Name;
                 data.push(String::from(m.get(0).unwrap().as_str()));
-                event!(Level::TRACE, "\nMatch: {}", data[0]);
-                (state, Some(ParseResult::Match(data)))
+                event!(Level::TRACE, "\nCaptures: {}", data[0]);
+                (state, Some(ParseResult::Capture(data)))
             } else {
                 event!(
                     Level::TRACE,

--- a/bl808-data/src/lib.rs
+++ b/bl808-data/src/lib.rs
@@ -181,7 +181,7 @@ pub fn parseit(
         }
         // Looking for name of the union: "} soc_info0;"
         ParseState::Name => {
-            if let Some(m) = regex!(r"\s*} ([a-z_\-\d]*);").captures(&line) {
+            if let Some(m) = regex!(r"\s*}\s*([a-zA-Z_\-\d]*);").captures(&line) {
                 state = ParseState::BlockName;
                 data.push(String::from(m.get(1).unwrap().as_str()));
                 event!(Level::TRACE, "\nCaptures: {}", data[0]);

--- a/bl808-data/src/lib.rs
+++ b/bl808-data/src/lib.rs
@@ -161,7 +161,7 @@ pub fn parseit(
         }
         // Looking for 2nd union member: "uint32_t WORD;"
         ParseState::Size => {
-            if let Some(m) = regex!(r"\s*(uint32_t) WORD;").captures(&line) {
+            if let Some(m) = regex!(r"\s*(uint32_t)\s*WORD;").captures(&line) {
                 state = ParseState::Name;
                 data.push(String::from(m.get(0).unwrap().as_str()));
                 event!(Level::TRACE, "\nCaptures: {}", data[0]);

--- a/bl808-data/src/parser.rs
+++ b/bl808-data/src/parser.rs
@@ -133,8 +133,10 @@ impl Parser {
                             // println!("whats my name? {n:?}")
                         }
                         crate::ParseResult::Capture(c) => {
-                            if let Some(reg) = self.register.as_mut() {
+                            if let Some(mut reg) = self.register.take() {
                                 reg.name = c[0].clone();
+                                // At this point our register is complete, push it.
+                                self.registers.push(reg);
                             }
                         }
                     }

--- a/bl808-data/src/parser.rs
+++ b/bl808-data/src/parser.rs
@@ -29,20 +29,6 @@ impl Parser {
             ParseState::PeripheralStart => {} // Don't do anything with peri
             ParseState::RegAddress => {
                 if let Some(parse) = parse_result {
-                    match parse {
-                        crate::ParseResult::Match(_n) => {
-                            // println!("whats my name? {n:?}")
-                        }
-                        crate::ParseResult::Capture(c) => {
-                            if let Some(reg) = self.register.as_mut() {
-                                reg.name = c[0].clone();
-                            }
-                        }
-                    }
-                }
-            }
-            ParseState::UnionStart => {
-                if let Some(parse) = parse_result {
                     if let Some(reg) = &self.register {
                         self.registers.push(reg.clone());
                     }
@@ -57,6 +43,7 @@ impl Parser {
                     self.register = Some(reg);
                 }
             }
+            ParseState::UnionStart => {}
             ParseState::StructStart => {}
             ParseState::FieldEntry => {
                 if let Some(parse) = parse_result {
@@ -96,36 +83,7 @@ impl Parser {
                     }
                 }
             }
-            ParseState::EndOfStruct => {
-                if let Some(parse) = parse_result {
-                    let mut field = Field::new();
-                    match parse {
-                        crate::ParseResult::Match(_) => panic!("Not expecting match"),
-                        crate::ParseResult::Capture(c) => {
-                            field.name = c[0].trim().to_string();
-                            // c[1] is number of bits, we don't need that.
-                            if c[2].contains(':') {
-                                let mut c_arr = c[2].split(':');
-                                let msb = c_arr.next();
-                                let lsb = c_arr.next();
-                                field.msb = msb.unwrap().trim().to_string();
-                                field.lsb = lsb.unwrap().trim().to_string();
-                            } else {
-                                field.msb = c[2].trim().to_string();
-                                field.lsb = field.msb.clone();
-                            }
-                            field.access = c[3].trim().to_string();
-                            field.reset_value = c[4].trim().to_string();
-                        }
-                    }
-                    // println!("field  {field:?}");
-                    if let Some(reg) = self.register.as_mut() {
-                        reg.fields.push(field);
-                    }
-                } else {
-                    // println!("fielding the wrong question?");
-                }
-            }
+            ParseState::EndOfStruct => {}
             ParseState::Size => {}
             ParseState::Name => {
                 if let Some(parse) = parse_result {

--- a/bl808-data/src/parser.rs
+++ b/bl808-data/src/parser.rs
@@ -24,7 +24,8 @@ impl Parser {
 
     pub fn parse(&mut self, line_num: usize, line: String) {
         let (newstate, parse_result) = parseit(self.state, line, line_num);
-        match newstate {
+        // Match against the state *before* we parsed (we might have transitioned due to parseit)
+        match self.state {
             ParseState::PeripheralStart => {} // Don't do anything with peri
             ParseState::RegAddress => {
                 if let Some(parse) = parse_result {

--- a/bl808-data/src/parser.rs
+++ b/bl808-data/src/parser.rs
@@ -45,6 +45,7 @@ impl Parser {
             }
             ParseState::UnionStart => {}
             ParseState::StructStart => {}
+            ParseState::StructStart2 => {}
             ParseState::FieldEntry => {
                 if let Some(parse) = parse_result {
                     let mut field = Field::new();

--- a/bl808-data/src/parser.rs
+++ b/bl808-data/src/parser.rs
@@ -16,7 +16,7 @@ pub struct Parser {
 impl Parser {
     pub fn new() -> Parser {
         Parser {
-            state: ParseState::NoMatch,
+            state: ParseState::PeripheralStart,
             register: None,
             registers: vec![],
         }
@@ -25,8 +25,8 @@ impl Parser {
     pub fn parse(&mut self, line_num: usize, line: String) {
         let (newstate, parse_result) = parseit(self.state, line, line_num);
         match newstate {
-            ParseState::NoMatch => {}
-            ParseState::BlockName => {
+            ParseState::PeripheralStart => {} // Don't do anything with peri
+            ParseState::RegAddress => {
                 if let Some(parse) = parse_result {
                     match parse {
                         crate::ParseResult::Match(_n) => {
@@ -40,7 +40,7 @@ impl Parser {
                     }
                 }
             }
-            ParseState::BlockAddr => {
+            ParseState::UnionStart => {
                 if let Some(parse) = parse_result {
                     if let Some(reg) = &self.register {
                         self.registers.push(reg.clone());
@@ -56,8 +56,8 @@ impl Parser {
                     self.register = Some(reg);
                 }
             }
-            ParseState::UnionStr => {}
-            ParseState::StructStr => {
+            ParseState::StructStart => {}
+            ParseState::FieldEntry => {
                 if let Some(parse) = parse_result {
                     let mut field = Field::new();
                     match parse {
@@ -95,7 +95,7 @@ impl Parser {
                     }
                 }
             }
-            ParseState::Field => {
+            ParseState::EndOfStruct => {
                 if let Some(parse) = parse_result {
                     let mut field = Field::new();
                     match parse {

--- a/bl808-data/src/parser/field.rs
+++ b/bl808-data/src/parser/field.rs
@@ -33,13 +33,21 @@ impl fmt::Display for Field {
 /// map these through to SVD versions
 pub fn svd_access_map(access: &str) -> &str {
     match access {
-        "r/w" => "read-write",
-        "rw" => "read-write",
         "r" => "read-only",
+        "R" => "read-only",
+        "rw" => "read-write",
+        "RW" => "read-write",
+        "RW1C" => "read-write", // TODO: needs oneToClear in modifiedWriteValues.
+        "RWAC" => "read-write", // TODO: needs anyToClear? in modifiedWriteValues.
+        "r/w" => "read-write",
+        "RO" => "read-only",
+        "ROC" => "read-only", // TODO: needs readToClear? in modifiedWriteValues.
         "w" => "write-only",
+        "WO" => "write-only",
         "w1p" => "write-only", // TODO: needs oneTo(something) in modifiedWriteValues.
         "w1c" => "write-only", // TODO: needs oneToClear in modifiedWriteValues.
         "rsvd" => "read-only",
+        "RSVD" => "read-only",
         _ => "UNMAPPED_PLZ_FIX",
     }
 }


### PR DESCRIPTION
Was having a hard time keeping the state-machine sync in my head, so made the current parse state be what we're looking for.
This make its much easier to know:
- what strings we were looking for
- what data we expect back

This can now parse a bunch more headers than it could previously.